### PR TITLE
Changed NR_TsENS_VX to X2

### DIFF
--- a/OzFlux_std_2024_IRGASON.CR1X
+++ b/OzFlux_std_2024_IRGASON.CR1X
@@ -186,7 +186,7 @@ Const T_RH_T_OFFSET = -40         'Unique offset for temperature; HC2S3 = -40, H
 
 Const NR_ANALOG_INPUT = 3            'Unique differential analog input channel.
 Const NR_TsENS_ANALOG_INPUT = 13     'Unique single-ended analog input channel for body T
-Const NR_TsENS_VX = X1               'Unique voltage excitation channel for thermistor
+Const NR_TsENS_VX = X2               'Unique voltage excitation channel for thermistor
 Const NR_SW_INCOMING_CAL = 1000/15   'Unique multiplier for CNR 4 shortwave incoming radiation (1000/sensitivity).
 Const NR_SW_OUTGOING_CAL = 1000/15   'Unique multiplier for CNR 4 shortwave outgoing radiation (1000/sensitivity).
 Const NR_LW_INCOMING_CAL = 1000/8    'Unique multiplier for CNR 4 longwave incoming radiation (1000/sensitivity).
@@ -208,7 +208,7 @@ Const NR_LW_OUTGOING_CAL = 1000/8    'Unique multiplier for CNR 4 longwave outgo
 '7H      Thermistor signal (white)
 'gnd     Thermistor signal reference (black)
 '        Shield (clear)
-'X1      Thermistor excitation (red)
+'X2      Thermistor excitation (red)
 
 ' *** End user-customised station / logger / instrument constanTs and wiring ***
 ' *** CUSTOMISE THE BELOW AT YOUR OWN RISK!!!


### PR DESCRIPTION
The X2 port is physically closer to the other ports for the CNR4 sensor (e.g. port 13 for T body). This keeps CNR4 wiring confined to one sector of the CNR4 wiring panel. And, in case original CNR4 cables from Kipp & Zonen are used instead of cables from Campbell, a resistor must be installed on the X port and that resistor must reach the neighbouring port.