### PR TITLE
rH multiplier documentation

### DIFF
--- a/WSF_2024.CR6
+++ b/WSF_2024.CR6
@@ -141,7 +141,7 @@ Const RAIN_CAL = 0.2               'Unique multiplier for tipping bucket.
 Const T_RH_MAIN_INPUT = 1          'Unique differential input channel for temperature and humidity probe.
 Const T_RH_T_MULT = 0.14           'Unique multiplier for temperature; HC2S3 = 0.1, HMP155A = 0.14, or HMP45C = 0.1.
 Const T_RH_T_OFFSET = -80          'Unique offset for temperature; HC2S3 = -40, HMP155A = -80, or HMP45C = -40.
-Const T_RH_RH_MULT = 0.1           'Unique multiplier for rh; HC2S3 = ?, HMP155A = 0.001, or HMP45C = ?.
+Const T_RH_RH_MULT = 0.1           'Unique multiplier for rh; HC2S3 = ?, HMP155A = 0.001, or HMP45C = ?. From CSA manual HMP155 "Humidity reported as a percent – set Mult to 0.1 and Offset to 0", "Humidity reported as a fraction – set Mult to 0.001 and Offset to 0"
 Const T_RH_RH_OFFSET = 0           'Unique offset for rh; HC2S3 = ?, HMP155A = 0, or HMP45C = ?.
 
 '1H      Temperature signal (yellow)


### PR DESCRIPTION
There is ambiguity in the definition and documentation for T_RH_RH_MULT = 0.1. The comment in the code suggests to use 0.001 for the Vaisala HMP155 sensor, but the value 0.1 is actually used! Both is fine, this PR adds documentation on the different effect of the multiplier setting:
Added information from the manual on the rH multiplier for Vaisala HMP155 sensor. Depending on desired output, (percentage or fraction) a different multiplier us uses. Currently, the HMP155 sensor for WSF is set to report rH as percentage, hence mult = 0.1, even tough the comment in the code says to use 0.001 (i.e. fraction).